### PR TITLE
feat: CRUD API구현(RESTful API)

### DIFF
--- a/src/main/java/com/study/url_shorter/domain/url/controller/UrlController.java
+++ b/src/main/java/com/study/url_shorter/domain/url/controller/UrlController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/urls")
 public class UrlController {
@@ -24,10 +26,31 @@ public class UrlController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
+    @GetMapping
+    public ResponseEntity<List<UrlResponseDto>> getAllUrls() {
+        return urlService.getAllUrls()
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @GetMapping("/{shortUrl}")
     public ResponseEntity<UrlResponseDto> getOriginalUrl(@PathVariable("shortUrl") String shortUrl) {
         return urlService.getOriginalUrl(shortUrl)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{shortUrl}")
+    public ResponseEntity<UrlResponseDto> updateShortUrl(
+            @PathVariable("shortUrl") String shortUrl,
+            @Valid @RequestBody UrlRequestDto requestDto) {
+        UrlResponseDto responseDto = urlService.updateShortUrl(shortUrl, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @DeleteMapping("/{shortUrl}")
+    public ResponseEntity<Void> deleteShortUrl(@PathVariable("shortUrl") String shortUrl) {
+        urlService.deleteShortUrl(shortUrl);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/study/url_shorter/domain/url/repository/UrlRepository.java
+++ b/src/main/java/com/study/url_shorter/domain/url/repository/UrlRepository.java
@@ -3,8 +3,10 @@ package com.study.url_shorter.domain.url.repository;
 import com.study.url_shorter.domain.url.entity.Url;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UrlRepository extends JpaRepository<Url, Long> {
-    Optional<Url> findByShortUrl(String shortUrl);
+    Optional<Url> findByShortUrlAndIsDeletedFalse(String shortUrl);
+    List<Url> findAllByIsDeletedFalse();
 }

--- a/src/main/java/com/study/url_shorter/domain/url/service/UrlService.java
+++ b/src/main/java/com/study/url_shorter/domain/url/service/UrlService.java
@@ -3,10 +3,16 @@ package com.study.url_shorter.domain.url.service;
 import com.study.url_shorter.domain.url.dto.UrlRequestDto;
 import com.study.url_shorter.domain.url.dto.UrlResponseDto;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UrlService {
 
     UrlResponseDto createShortUrl(UrlRequestDto requestDto);
+
+    Optional<List<UrlResponseDto>> getAllUrls();
     Optional<UrlRequestDto> getOriginalUrl(String shortUrl);
+
+    void deleteShortUrl(String shortUrl);
+
 }


### PR DESCRIPTION
# RESTfulAPI 설계 및 구현

## 1. 왜 RESTful하게 API를 설계하는가?
범용 인터페이(RESTful API)을 사용해서 클라이언트와 백엔드 모두 효과적으로 개발을 할 수 있게 된다.

그럼, RESTful한 API는 뭐가 좋은걸까?

1. 자원의 명확한 표현(Resource_Oriented)
: 모든 데이터를 "자원(Resource)"으로 보고, URL로 그 자원을 식별한다. 왜냐면, 클라이언트가 직관적으로 어떤 데이터를 다루는지 알 수 있고, URL만 봐도 기능이 예측 가능해지기 때문에.

2. 확장성
: 상태 비저장성(Stateless)덕분에 분산처리가 가능하다.

3. 유연성과 독립성
: RESTful API는 사용되는 기술(언어, 프레임워크)과 독립적이다. 기술 변경이 되더라도 전혀 상관이없다.

## 2. RESTful 한 구현

1. HTTP메서드 사용
![image](https://github.com/user-attachments/assets/d7e5c014-c950-4972-9a67-f85325af12ee)

+ PUT vs PATCH
 original Url을 변경하는 PATCH메서드의 경우 PUT을 사용하지 않았다. 
PUT은 전체 리소스를 변경하고, 그렇기 때문에 멱등성을 보장한다. 하지만, PATCH의 경우에는 부분을 변경하고, 멱등성을 보장하지 않는다. 이 경우 original_url 값만 변경되기 때문에 PATCH를 사용했다.

2. 자원의 출처 표시
- "api/v1/urls"
계층구조를 사용하고, 소문자를 사용하고, 명사로 표현했다. v1같은 경우는 버전을 표현하기위해 삽입했다.
